### PR TITLE
module: common/get_extra: a few changes

### DIFF
--- a/module/common/get_extra.sh
+++ b/module/common/get_extra.sh
@@ -35,7 +35,7 @@ get_unnecessary() {
 get_xposed() {
     pm list packages -3 | cut -d':' -f2 | grep -vxF -f "$SKIPLIST" | grep -vxF -f "$OUTPUT" | while read -r PACKAGE; do
         APK_PATH=$(pm path "$PACKAGE" | grep "base.apk" | cut -d':' -f2 | tr -d '\r')
-        if [[ -n "$APK_PATH" ]]; then
+        if [ -n "$APK_PATH" ]; then
             if aapt dump xmltree "$APK_PATH" AndroidManifest.xml 2>/dev/null | grep -qE "xposed.category|xposeddescription"; then
                 echo "$PACKAGE" >> "$OUTPUT"
             fi

--- a/module/common/get_extra.sh
+++ b/module/common/get_extra.sh
@@ -1,11 +1,22 @@
-#!/system/bin/sh
-
+#!/bin/sh
+PATH=/data/adb/ap/bin:/data/adb/ksu/bin:/data/adb/magisk:/data/data/com.termux/files/usr/bin:$PATH
 MODPATH=${0%/*}
 SKIPLIST="$MODPATH/tmp/skiplist"
 OUTPUT="$MODPATH/tmp/exclude-list"
 KBOUTPUT="$MODPATH/tmp/.extra"
 
 aapt() { "$MODPATH/aapt" "$@"; }
+
+# probe for downloaders
+# wget = low pref, no ssl.
+# curl, has ssl on android, we use it if found
+download() {
+	if command -v curl > /dev/null 2>&1; then
+		curl --connect-timeout 3 -s "$1"
+        else
+		busybox wget -T 3 --no-check-certificate -qO - "$1"
+        fi
+}      
 
 get_kb() {
     check_wget

--- a/module/common/get_extra.sh
+++ b/module/common/get_extra.sh
@@ -23,15 +23,6 @@ get_kb() {
     [ -s "$KBOUTPUT" ] || rm -f "$KBOUTPUT"
 }
 
-get_unnecessary() {
-    if [ ! -s "$OUTPUT" ] || [ ! -f "$OUTPUT" ]; then
-        download "https://raw.githubusercontent.com/KOWX712/Tricky-Addon-Update-Target-List/main/more-excldue.json" 2>/dev/null | \
-        grep -o '"package-name": *"[^"]*"' | \
-        awk -F'"' '{print $4}' > "$OUTPUT"
-    fi
-    get_xposed
-}
-
 get_xposed() {
     pm list packages -3 | cut -d':' -f2 | grep -vxF -f "$SKIPLIST" | grep -vxF -f "$OUTPUT" | while read -r PACKAGE; do
         APK_PATH=$(pm path "$PACKAGE" | grep "base.apk" | cut -d':' -f2 | tr -d '\r')
@@ -41,6 +32,15 @@ get_xposed() {
             fi
         fi
     done
+}
+
+get_unnecessary() {
+    if [ ! -s "$OUTPUT" ] || [ ! -f "$OUTPUT" ]; then
+        download "https://raw.githubusercontent.com/KOWX712/Tricky-Addon-Update-Target-List/main/more-excldue.json" 2>/dev/null | \
+        grep -o '"package-name": *"[^"]*"' | \
+        awk -F'"' '{print $4}' > "$OUTPUT"
+    fi
+    get_xposed
 }
 
 check_update() {

--- a/module/common/get_extra.sh
+++ b/module/common/get_extra.sh
@@ -4,23 +4,6 @@ MODPATH=${0%/*}
 SKIPLIST="$MODPATH/tmp/skiplist"
 OUTPUT="$MODPATH/tmp/exclude-list"
 KBOUTPUT="$MODPATH/tmp/.extra"
-BBPATH="/data/adb/magisk/busybox \
-/data/adb/ksu/bin/busybox \
-/data/adb/ap/bin/busybox \
-/data/adb/modules/busybox-ndk/system/*/busybox"
-
-check_wget() {
-    for path in $BBPATH; do
-        [ -f "$path" ] && BUSYBOX="$path" && break
-    done
-    if ! command -v wget >/dev/null || grep -q "wget-curl" "$(command -v wget)"; then
-        if [ -n "$BUSYBOX" ]; then
-            wget() { "$BUSYBOX" wget "$@"; }
-        else
-            exit 1
-        fi
-    fi
-}
 
 aapt() { "$MODPATH/aapt" "$@"; }
 

--- a/module/common/get_extra.sh
+++ b/module/common/get_extra.sh
@@ -19,15 +19,13 @@ download() {
 }      
 
 get_kb() {
-    check_wget
-    wget --no-check-certificate -qO "$KBOUTPUT" "https://raw.githubusercontent.com/KOWX712/Tricky-Addon-Update-Target-List/main/.extra"
+    download "https://raw.githubusercontent.com/KOWX712/Tricky-Addon-Update-Target-List/main/.extra" > "$KBOUTPUT" 
     [ -s "$KBOUTPUT" ] || rm -f "$KBOUTPUT"
 }
 
 get_unnecessary() {
-    check_wget
     if [ ! -s "$OUTPUT" ] || [ ! -f "$OUTPUT" ]; then
-        wget --no-check-certificate -q -O - "https://raw.githubusercontent.com/KOWX712/Tricky-Addon-Update-Target-List/main/more-excldue.json" 2>/dev/null | \
+        download "https://raw.githubusercontent.com/KOWX712/Tricky-Addon-Update-Target-List/main/more-excldue.json" 2>/dev/null | \
         grep -o '"package-name": *"[^"]*"' | \
         awk -F'"' '{print $4}' > "$OUTPUT"
     fi
@@ -46,9 +44,8 @@ get_xposed() {
 }
 
 check_update() {
-    check_wget
     if [ -d "$MODPATH/update" ]; then
-        JSON=$(wget --no-check-certificate -q -O - "https://raw.githubusercontent.com/KOWX712/Tricky-Addon-Update-Target-List/main/update.json") || exit 1
+        JSON=$(download "https://raw.githubusercontent.com/KOWX712/Tricky-Addon-Update-Target-List/main/update.json") || exit 1
         REMOTE_VERSION=$(echo "$JSON" | grep -o '"versionCode": *[0-9]*' | awk -F: '{print $2}' | tr -d ' ')
         LOCAL_VERSION=$(grep -o 'versionCode=[0-9]*' "$MODPATH/update/module.prop" | awk -F= '{print $2}')
         if [ "$REMOTE_VERSION" -gt "$LOCAL_VERSION" ]; then


### PR DESCRIPTION
make sure to test them first
stage properly and see if something broke

changes are split into 5 to better explain what the changes are.

more context:

usage in bindhosts
https://github.com/backslashxx/bindhosts/blob/master/module/bindhosts.sh#L129

if some people are having ipv6 issues, atleast with curl you can force them onto ipv4
just change 
```shell
curl --connect-timeout 10 -s "$1"
```
to
```shell
curl --connect-timeout 10 -4 -s "$1"
```

you dont need to ship curl, but if it is found, it will be used
non-stripped ROMs have curl and if user has termux, it also has curl
if curl isnt found in PATH, it will just use busybox wget, which is available on 
manager's PATH /data/adb/ap/bin:/data/adb/ksu/bin:/data/adb/magisk