### PR TITLE
Prevent code injection from downloaded keybox file

### DIFF
--- a/module/webui/scripts/menu_option.js
+++ b/module/webui/scripts/menu_option.js
@@ -173,12 +173,14 @@ export async function setupSystemAppMenu() {
     }
 }
 
+
 // Function to backup previous keybox and set new keybox
 async function setKeybox(content) {
+    const sanitizedContent = content.replace(/'/g, "'\\''");
     try {
         await execCommand(`
             mv -f /data/adb/tricky_store/keybox.xml /data/adb/tricky_store/keybox.xml.bak 2>/dev/null
-            echo '${content}' > /data/adb/tricky_store/keybox.xml
+            echo '${sanitizedContent}' > /data/adb/tricky_store/keybox.xml
             chmod 644 /data/adb/tricky_store/keybox.xml
             `);
         return true;

--- a/module/webui/scripts/menu_option.js
+++ b/module/webui/scripts/menu_option.js
@@ -173,7 +173,6 @@ export async function setupSystemAppMenu() {
     }
 }
 
-
 // Function to backup previous keybox and set new keybox
 async function setKeybox(content) {
     const sanitizedContent = content.replace(/'/g, "'\\''");


### PR DESCRIPTION
The downloading of the keybox file from this repo by the module causes a potential attack vector:
1. PR is created preporting to add an unrevoked keybox file
2. Maintainer approves PR without unobfuscating keybox file to check contents
3. All devices that run the "Set valid keybox" action are pwned

This PR adds sanitization to prevent such an attack.