### PR TITLE
Bump Actions Plugin Versions 

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,7 +19,7 @@ jobs:
       version_tag_exists: ${{ steps.check_tag.outputs.version_tag_exists }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 0
           fetch-tags: true
@@ -65,7 +65,7 @@ jobs:
           echo "VERSION=${MODULE_VERSION}" >> $GITHUB_ENV
 
       - name: Upload Artifact
-        uses: actions/upload-artifact@v4
+        uses: actions/upload-artifact@v4.6.2
         with:
           name: ${{ env.ARTIFACT_NAME }}
           path: module/
@@ -93,7 +93,7 @@ jobs:
     if: ${{ needs.build.outputs.version_tag_exists == 'false' && github.event_name != 'pull_request' }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           fetch-depth: 2
 
@@ -127,7 +127,7 @@ jobs:
           cd module && zip -r "../${{ env.ZIP_NAME }}" ./*
 
       - name: Create release
-        uses: softprops/action-gh-release@v2
+        uses: softprops/action-gh-release@v2.2.2
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         with:

--- a/.github/workflows/crowdin.yml
+++ b/.github/workflows/crowdin.yml
@@ -14,10 +14,10 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: Checkout
-      uses: actions/checkout@v4
+      uses: actions/checkout@v4.2.2
 
     - name: Crowdin Action
-      uses: crowdin/github-action@v1
+      uses: crowdin/github-action@v2.7.0
       with:
         upload_sources: true
         upload_translations: true

--- a/.github/workflows/generate.yml
+++ b/.github/workflows/generate.yml
@@ -11,7 +11,7 @@ jobs:
 
     steps:
       - name: Checkout Repository
-        uses: actions/checkout@v4
+        uses: actions/checkout@v4.2.2
         with:
           ref: 'bot'
 


### PR DESCRIPTION
This pull request updates GitHub Actions workflows to use more recent versions of their respective actions. These updates improve compatibility, security, and access to the latest features.

### Workflow updates in `.github/workflows/build.yml`:

* Updated `actions/checkout` from `v4` to `v4.2.2` in multiple steps to ensure consistency and access to the latest improvements. [[1]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L22-R22) [[2]](diffhunk://#diff-5c3fa597431eda03ac3339ae6bf7f05e1a50d6fc7333679ec38e21b337cb6721L96-R96)
* Updated `actions/upload-artifact` from `v4` to `v4.6.2` to leverage enhancements and fixes in artifact uploads.
* Updated `softprops/action-gh-release` from `v2` to `v2.2.2` for improved release creation support.

### Workflow updates in `.github/workflows/crowdin.yml`:

* Updated `actions/checkout` from `v4` to `v4.2.2` for consistency with other workflows.
* Updated `crowdin/github-action` from `v1` to `v2.7.0` to utilize the latest features for managing translations.

### Workflow updates in `.github/workflows/generate.yml`:

* Updated `actions/checkout` from `v4` to `v4.2.2` for improved compatibility.