### PR TITLE
Remove support for mmrl webui

### DIFF
--- a/module/action.sh
+++ b/module/action.sh
@@ -49,9 +49,6 @@ get_webui() {
 if pm path io.github.a13e300.ksuwebui >/dev/null 2>&1; then
     echo "- Launching WebUI in KSUWebUIStandalone..."
     am start -n "io.github.a13e300.ksuwebui/.WebUIActivity" -e id "tricky_store"
-elif pm path com.dergoogler.mmrl >/dev/null 2>&1; then
-    echo "- Launching WebUI in MMRL WebUI..."
-    am start -n "com.dergoogler.mmrl/.ui.activity.webui.WebUIActivity" -e MOD_ID "tricky_store"
 elif pm path com.dergoogler.mmrl.wx > /dev/null 2>&1; then
     echo "- Launching WebUI in WebUI X..."
     am start -n "com.dergoogler.mmrl.wx/.ui.activity.webui.WebUIActivity" -e MOD_ID "tricky_store"


### PR DESCRIPTION
mmrl has removed webui.
removing the call altogether fixes the silent failure and the webuix call from being unreachable if mmrl is still installed. 